### PR TITLE
Fix some small erratta on the l8 docs

### DIFF
--- a/docs/devices/lanbon-l8.md
+++ b/docs/devices/lanbon-l8.md
@@ -142,10 +142,20 @@ Pin| Mode   | L8-HD      | Group | Default
 32 | Output | Mood Green | 5 | Low (Normal)
 33 | Output | Mood Blue  | 6 | Low (Normal)
 
+!!! note "Warning"
+    There are two versions of the dimmer configuration: `EU` and `AU`. The protocol used to command the dimmer module differs between the two!
+    Make sure that you have the correct type configured under your GPIO Output settings for pin `12`. Use the `AU` configuration for any 120V/US compatible dimmer modules.
+
 !!! tip
-    To configure the GPIOs at once for L8-HD send to topic `hasp/<nodename>/config` a message with payload:  
+    To configure the GPIOs at once for L8-HD send to topic `hasp/<nodename>/config/gpio` a message with payload:
+    EU version:
     ```json linenums="1"
-    {"gpio":{"config":[3211532,197658,263456,329249,0,0,0,0]}}
+    {"config":[3211532,197658,263456,329249,0,0,0,0]}
+    ```
+
+    AU/US version:
+    ```json linenums="1"
+    {"config":[3277068,197658,263456,329249,0,0,0,0]}
     ```
 
 ### Boiler version L8-HB


### PR DESCRIPTION
The GPIO configuration command was (slightly) incorrect as written, can be simplified.
Also added a note about the (slight) difference between the au/us and eu versions.

This is from telnet log on a device. First payload is as the docs suggest and results in a `config not found` message.
The second payload is the same as the docs suggest but to the `/gpio` sub topic... it works
The third payload is a slightly smaller json payload sent to the same sub topic... and it works.

```
[13:01:53.224][65524/114064 42][41484/42056  2] MQTT RCV: hasp/somePlate/config = {"gpio":{"config":[3277068,197658,263456,329249,0,0,0,0]}}
[13:01:53.246][65524/114064 42][41484/42056  2] MSGR: Command 'config' not found => {"gpio":{"config":[3277068,197658,263456,329249,0,0,0,0]}}
[13:02:02.886][65524/114064 42][41484/42056  2] MQTT RCV: hasp/somePlate/config/gpio = {"gpio":{"config":[3277068,197658,263456,329249,0,0,0,0]}}
[13:02:02.907][65524/113188 42][41484/42056  2] CONF: {"gpio":{"config":[3277068,197658,263456,329249,0,0,0,0]}}
[13:02:16.740][65524/114064 42][41484/42056  2] MQTT RCV: hasp/somePlate/config/gpio = {"config":[3277068,197658,263456,329249,0,0,0,0]}
[13:02:16.764][65524/113200 42][41484/42056  2] CONF: {"config":[3277068,197658,263456,329249,0,0,0,0]}

```