### PR TITLE
Document screenshot command for Mac desktop build

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -285,6 +285,8 @@ This can be handy for bug reporting or documentation.
 
 The previous screenshot is overwritten.
 
+On the **Mac desktop build**, the screenshot is saved as `screenshot.bmp` in the working directory. You can optionally pass a custom file path as a parameter. Press **F12** in the simulator window as a shortcut.
+
 ### `service`
 
 Start or stop some of the processes running on the plate.

--- a/docs/commands/system.md
+++ b/docs/commands/system.md
@@ -45,6 +45,11 @@ This can be handy for bug reporting or documentation.
 
 The previous screenshot is overwritten.
 
+On the **Mac desktop build**, the screenshot is saved as `screenshot.bmp` in the working directory. You can optionally pass a custom file path as a parameter.
+
+!!! tip
+    Press **F12** in the simulator window to take a screenshot without using MQTT.
+
 ## `service`
 
 Start or stop some of the processes running on the plate.


### PR DESCRIPTION
## Summary

- Document the `screenshot` command behavior on the Mac desktop build in both `docs/commands/system.md` and `docs/commands.md`
- Notes that screenshots are saved as `screenshot.bmp` in the working directory, with optional custom file path
- Documents the F12 keyboard shortcut in the simulator window

Companion code PR: https://github.com/HASwitchPlate/openHASP/pull/997