### PR TITLE
Update screenshot docs to include Linux build

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -285,7 +285,7 @@ This can be handy for bug reporting or documentation.
 
 The previous screenshot is overwritten.
 
-On the **Mac desktop build**, the screenshot is saved as `screenshot.bmp` in the working directory. You can optionally pass a custom file path as a parameter. Press **F12** in the simulator window as a shortcut.
+On the **desktop builds** (Mac and Linux), the screenshot is saved as `screenshot.bmp` in the working directory. You can optionally pass a custom file path as a parameter. Press **F12** in the simulator window as a shortcut.
 
 ### `service`
 

--- a/docs/commands/system.md
+++ b/docs/commands/system.md
@@ -45,7 +45,7 @@ This can be handy for bug reporting or documentation.
 
 The previous screenshot is overwritten.
 
-On the **Mac desktop build**, the screenshot is saved as `screenshot.bmp` in the working directory. You can optionally pass a custom file path as a parameter.
+On the **desktop builds** (Mac and Linux), the screenshot is saved as `screenshot.bmp` in the working directory. You can optionally pass a custom file path as a parameter.
 
 !!! tip
     Press **F12** in the simulator window to take a screenshot without using MQTT.


### PR DESCRIPTION
## Summary

- Update screenshot command documentation to reflect that the feature now works on both **Mac and Linux** builds (previously only documented for Mac)
- Updates both `docs/commands.md` and `docs/commands/system.md`

Follow-up to:

- Original Mac screenshot docs PR: #50
- Original code PR: https://github.com/HASwitchPlate/openHASP/pull/997
- Linux build fix PR: https://github.com/HASwitchPlate/openHASP/pull/998