### PR TITLE
4827S043: document working resistive touch (standalone XPT2046)

### DIFF
--- a/docs/hardware/sunton/esp32-4827s043.md
+++ b/docs/hardware/sunton/esp32-4827s043.md
@@ -74,9 +74,7 @@ or the latest found under <a target="_blank" href="https://github.com/HASwitchPl
 
 Note that some of the screens have **TWO** versions, **Resistive** and **Capacitive**, so flash the correct firmware (ends in `r` or a `c` respectively).
 
-**RESISTIVE**: After first boot, Run a `Calibration` via the web ui -> Display Setup -> Calibrate
-
-Then on the screen, touch the indicated points.
+**RESISTIVE**: The `r` firmware drives resistive touch with a standalone XPT2046 driver (this board's RGB-parallel panel is driven by ArduinoGFX, so touch runs on its own SPI bus) and ships with a working calibration baked in for the panel, so it is usable out of the box. Its calibration is set via the `TOUCH_XPT2046_*` build flags (notably `SWAP_XY` and the raw min/max window) rather than the web UI *Display Setup -> Calibrate* flow — adjust those and recompile to fine-tune. Resistive-touch support for this board was added in [openHASP #1028](https://github.com/HASwitchPlate/openHASP/pull/1028).
 
 [1]: https://www.aliexpress.com/item/1005004788147691.html
 [2]: https://www.aliexpress.com/item/1005004788147691.html


### PR DESCRIPTION
Follow-up to [openHASP#1028](https://github.com/HASwitchPlate/openHASP/pull/1028), which adds working resistive (XPT2046) touch for the Sunton ESP32-4827S043**R**.

This page's **RESISTIVE** setup note told users to calibrate via *Display Setup → Calibrate* in the web UI. That doesn't apply to this board: its RGB-parallel panel is driven by ArduinoGFX, so touch runs through a **standalone XPT2046 driver** (its own SPI bus) that ships **pre-calibrated** and is tuned via `TOUCH_XPT2046_*` build flags, not the web-UI Calibrate flow.

The note is corrected to reflect that, and links the driver PR for provenance.

Verified on hardware (ESP32-4827S043R): display + calibrated resistive touch working.
